### PR TITLE
add gpg install to git image to allow for signed commits

### DIFF
--- a/Dockerfile.git
+++ b/Dockerfile.git
@@ -8,7 +8,7 @@ ARG RUN_CMD
 
 # analytics package target - we want a new layer here, since different
 # dependencies will have to be installed, sharing the common base above
-RUN DEBIAN_FRONTEND=noninteractive apt -y install git-all
+RUN DEBIAN_FRONTEND=noninteractive apt -y install git-all gpg
 
 ARG TEST="/test.sh"
 COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}


### PR DESCRIPTION
Not sure if anything else will be required to make this work, but this will just add gpg to the git image. As it stands on HPC, we cannot use gpg 2.1 compatible keyrings with git.